### PR TITLE
Respect existing content insets

### DIFF
--- a/XLForm/XL/Controllers/XLFormViewController.m
+++ b/XLForm/XL/Controllers/XLFormViewController.m
@@ -57,6 +57,8 @@
 @property UITableViewStyle tableViewStyle;
 @property (nonatomic) XLFormRowNavigationAccessoryView * navigationAccessoryView;
 
+@property UIEdgeInsets cachedInset;
+
 @end
 
 @implementation XLFormViewController
@@ -479,6 +481,7 @@
             [UIView beginAnimations:nil context:nil];
             [UIView setAnimationDuration:[keyboardInfo[UIKeyboardAnimationDurationUserInfoKey] doubleValue]];
             [UIView setAnimationCurve:[keyboardInfo[UIKeyboardAnimationCurveUserInfoKey] intValue]];
+            self.cachedInset = self.tableView.contentInset;
             self.tableView.contentInset = tableContentInset;
             self.tableView.scrollIndicatorInsets = tableScrollIndicatorInsets;
             NSIndexPath *selectedRow = [self.tableView indexPathForCell:cell];
@@ -501,7 +504,7 @@
         [UIView beginAnimations:nil context:nil];
         [UIView setAnimationDuration:[keyboardInfo[UIKeyboardAnimationDurationUserInfoKey] doubleValue]];
         [UIView setAnimationCurve:[keyboardInfo[UIKeyboardAnimationCurveUserInfoKey] intValue]];
-        self.tableView.contentInset = tableContentInset;
+        self.tableView.contentInset = self.cachedInset;
         self.tableView.scrollIndicatorInsets = tableScrollIndicatorInsets;
         [UIView commitAnimations];
     }


### PR DESCRIPTION
Cache any existing content inset before changing to make space for keyboard/editing accessory, restore when keyboard is dismissed
